### PR TITLE
set writable=true by default in nonenumerable

### DIFF
--- a/src/nonenumerable.js
+++ b/src/nonenumerable.js
@@ -1,7 +1,12 @@
 import { decorate } from './private/utils';
 
-function handleDescriptor(target, key, descriptor) {
+function handleDescriptor(target, key, descriptor, [options = {}]) {
   descriptor.enumerable = false;
+  
+  if (options.writable !== false) {
+    descriptor.writable = true;
+  }
+  
   return descriptor;
 }
 


### PR DESCRIPTION
Proposal for https://github.com/jayphelps/core-decorators.js/issues/78.

Makes nonenumerable decorator writable by default, unless the user explicitly set writable=false in decorator arguments.